### PR TITLE
Changed URL of Hackerspace TDvenlo

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -139,7 +139,7 @@
   "Tampa Hackerspace":"http://spaceapi.tampahackerspace.com/",
   "Tangleball":"http://www.tangleball.org.nz/wiki/index.php/Space_API?action=raw",
   "Tarlab":"http://tarlab.fi/spaceapi/space.api",
-  "TDVenlo":"https://tdvenlo.nl/spaceapi.json",
+  "TDvenlo":"https://spaceapi.tdvenlo.nl/spaceapi.json",
   "TechTonik Labs":"https://raw.github.com/sbhackerspace/sbhx-spaceapi/master/spaceapi.json",
   "Technologia Incognita":"http://techinc.nl/space/spacestate.json",
   "Terminal.21 Basislager":"http://api.terminal21.de",


### PR DESCRIPTION
Update the URL for the new TDvenlo spaceapi.json location and fixed a typo