### PR TITLE
Remove update_spaces.py from .travis-ci.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os: linux
 dist: trusty
 sudo: required
 language: python
-install: "pip install demjson requests"
+install: "pip install demjson"
 script:
     - "jsonlint --strict ./directory.json"
-    - "python update_spaces.py"


### PR DESCRIPTION
The script fetches all spaces for every commit, which is not necessary
at all. Travis should only validate that the directory itself is valid.

Fixes #108 