### PR TITLE
Update CCCP

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -31,7 +31,7 @@
   "Chaostreff Chemnitz": "https://chaoschemnitz.de/chch.json",
   "Chaostreff Dortmund": "http://status.ctdo.de/api/spaceapi/v13",
   "Chaostreff Flensburg": "https://api.chaostreff-flensburg.de/",
-  "Chaostreff Potsdam (CCCP)": "https://www.ccc-p.org/spaceapi.json",
+  "Chaostreff Potsdam (CCCP)": "https://spaceapi.ccc-p.org/",
   "Chaostreff Recklinghausen c3RE": "https://spaceapi.c3re.de/",
   "Chaostreff Salzburg": "https://spaceapi.sbg.chaostreff.at/status/json",
   "Chaostreff Zürich": "https://www.ccczh.ch/api/v13/",


### PR DESCRIPTION
The URL for Chaostreff Potsdam (CCCP) has changed.
New feature of the new version: the long awaited space status! :partying_face: 