### PR TITLE
Add RaumZeitLabor

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -120,6 +120,7 @@
   "Pixelbar": "https://spaceapi.pixelbar.nl/",
   "Polytechnischer Werkraum Zittau": "https://werkraum.freiraumzittau.de/spaceapi/13/",
   "Post Tenebras Lab": "https://www.posttenebraslab.ch/status/status.json",
+  "RaumZeitLabor": "https://status.raumzeitlabor.de/api/spaceapi.json",
   "Reaktor 23": "https://spaceapi.reaktor23.org",
   "Recompile": "http://www.recompile.se/spaceapi",
   "RevSpace": "https://revspace.nl/status/status.php",


### PR DESCRIPTION
I was a bit unsure if we should do the API in 0.13 or 14, so I kind of did both. Open/Closed-Status is currently inoperable because we moved and in the current COVID-Situation it would show closed all the time anyway. https://spaceapi.io/validator/ only complains about this status missing.