### PR TITLE
Madspace is closed

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -91,7 +91,6 @@
   "Liege Hackerspace": "https://lghs.be/spaceapi",
   "London Hackspace": "https://london.hackspace.org.uk/spaceapi",
   "LuXeria": "https://luxeria.ch/spaceapi.json",
-  "MADspace": "https://json.madspace.nl/spaceapi.json",
   "Maakplek": "http://maakplek.nl/api/",
   "Mainframe": "http://status.mainframe.io/api/spaceInfo",
   "MakeRiga": "https://api.makeriga.org/spaceapi.json",


### PR DESCRIPTION
Madspace exist no longer, as seen on their site https://www.madspace.nl/

"Stichting MADspace in liquidatie.
Bovengenoemde rechtspersoon is ontbonden per 3 juni 2021."