### PR TITLE
Move VoidWarranties url to https

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -152,7 +152,7 @@
   "UN-Hack-Bar": "https://keinanschluss.un-hack-bar.de/spaceapi.json",
   "Umeå Hackerspace": "http://umeahackerspace.se:12345/spaceapi.json",
   "UrLab": "https://urlab.be/spaceapi.json",
-  "VoidWarranties": "http://spaceapi.voidwarranties.be",
+  "VoidWarranties": "https://spaceapi.voidwarranties.be",
   "Warpzone e.V.": "https://api.warpzone.ms/spaceapi",
   "Warsaw Hackerspace": "https://hackerspace.pl/spaceapi",
   "Westwoodlabs": "https://api.westwoodlabs.de/spaceapi",


### PR DESCRIPTION
We've (finally) made our spaceapi available through https!

_We're not yet automatically redirecting http to https for some legacy reasons on our end but we plan to fix that real soon and that's not related to this PR._

Thanks for your consideration!