### PR TITLE
Move hackerspace.gr URL to https

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -68,7 +68,7 @@
   "Hackerspace Brussels": "https://api.hsbxl.be/index.php/api/spaceapi",
   "Hackerspace KRK": "http://hskrk-spacemon.herokuapp.com",
   "Hackerspace.Gent": "https://hackerspace.gent/spaceapi.php",
-  "Hackerspace.gr": "http://www.hackerspace.gr/spaceapi",
+  "Hackerspace.gr": "https://www.hackerspace.gr/spaceapi",
   "Hackerspace Szeged": "https://api.hackerspace-szeged.org",
   "Hacklab": "https://hacklab.kiev.ua/files/spaceapi.json",
   "Hacklabor": "https://hacklabor.de/api/space/v1/",


### PR DESCRIPTION
Avoid any redirect and list the correct endpoint directly.

Also fixes the ["My Hackerspace"](https://github.com/spaceapi-community/my-hackerspace) android widget for hsgr which doesn't handle the redirect correctly.