### PR TITLE
Update URL for Werkraum Zittau

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -129,7 +129,7 @@
   "Pangloss Labs #1": "https://spaceapi.panglosslabs.org/spaceapi.json",
   "Perth Artifactory": "http://space.artifactory.org.au/spaceapi.json",
   "Pixelbar": "https://spaceapi.pixelbar.nl/",
-  "Polytechnischer Werkraum Zittau": "https://werkraum.freiraumzittau.de/spaceapi/13/",
+  "Polytechnischer Werkraum Zittau": "https://www.werkraum.space/spaceapi/current/",
   "Pomerania Hackerspace": "https://status.hsp.sh/api/now",
   "Post Tenebras Lab": "https://www.posttenebraslab.ch/status/status.json",
   "RaumZeitLabor": "https://status.raumzeitlabor.de/api/spaceapi.json",


### PR DESCRIPTION
- moved to new domain name to avoid HTTP 301 redirect
- changed path to make it easier to switch between API versions