### PR TITLE
Change Umeå Hackerspace URL

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -155,7 +155,7 @@
   "TkkrLab": "https://spaceapi.tkkrlab.nl/",
   "Toolbox Bodensee e.V.": "https://toolbox-bodensee.de/toolboxbodensee.json",
   "UN-Hack-Bar": "https://keinanschluss.un-hack-bar.de/spaceapi.json",
-  "Umeå Hackerspace": "http://umeahackerspace.se:12345/spaceapi.json",
+  "Umeå Hackerspace": "https://umeahackerspace.se/spaceapi.json",
   "UrLab": "https://urlab.be/spaceapi.json",
   "VoidWarranties": "https://spaceapi.voidwarranties.be",
   "Warpzone e.V.": "https://api.warpzone.ms/spaceapi",


### PR DESCRIPTION
We recently had a server crash and finally got around to fixing things.
Now with HTTPS support!