### PR TITLE
Move Bytespeicher status url to https

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -13,7 +13,7 @@
   "Bitlair": "https://bitlair.nl/statejson.php",
   "Breizh-Entropy": "http://breizh-entropy.org/spaceapi.json",
   "Brixel": "https://status.brixel.space/api/status",
-  "Bytespeicher": "http://status.bytespeicher.org/status.json",
+  "Bytespeicher": "https://status.bytespeicher.org/status.json",
   "C3D2": "https://www.c3d2.de/spaceapi.json",
   "CCC Aachen": "https://status.aachen.ccc.de/spaceapi",
   "CCC Basel": "https://spaceapi.kabelsalat.ch/",


### PR DESCRIPTION
Bytespeicher status.json is delivered by default via https