### PR TITLE
Update name of "SFZ Aalen" and change the endpoint

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -143,7 +143,7 @@
   "Recompile": "http://www.recompile.se/spaceapi",
   "RevSpace": "https://revspace.nl/status/status.php",
   "Root": "https://bot.rootclub.it/spaceapi.json",
-  "Schülerforschungszentrum der Hochschule Aalen": "https://api.sfz-aalen.space/spaceapi.json",
+  "Hackwerk Aalen": "https://spaceapi.sfz-aalen.space/api/spaceapi.json",
   "SchonungsLos": "https://www.hackerspace-sw.de/spaceapi.json",
   "Segmentation Vault": "https://segvault.space/internal/spacecore/opendata/spaceapi",
   "Stockholm Makerspace": "https://raw.githubusercontent.com/makerspace/spaceapi/main/spaceapi.json",


### PR DESCRIPTION
Update "SFZ Aalen" to Chaostreff Aalen because the "Hackwerk Aalen" is the chaos community of the "SFZ Aalen" Through infrastructure changes the SpaceAPI Endpoint moved to a new location.