### PR TITLE
Updated the URL for 57North Hacklab

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -1,7 +1,7 @@
 {
   "/dev/tal": "https://www.devtal.de/api/",
   "/usr/space": "https://www.usrspace.at/spaceapi.json",
-  "57North Hacklab": "http://57north.co/spaceapi",
+  "57North Hacklab": "https://hub.57north.org.uk/spaceapi",
   "ACKspace": "https://ackspace.nl/spaceAPI/",
   "AFRA": "https://spaceapi.afra-berlin.de/v1/status.json",
   "Amman Valley MakerSpace": "https://raw.githubusercontent.com/AmmanVMS/space.api/main/api.json",


### PR DESCRIPTION
The URL for the 57North Hacklab has been updated to this new address.