### PR TITLE
Remove Netzladen from directory

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -126,7 +126,6 @@
   "Nerd2Nerd": "https://api.nerd2nerd.org/status.json",
   "Nerdberg": "https://status.nerdberg.de/api/space",
   "Netz39": "http://spaceapi.n39.eu/json",
-  "Netzladen": "http://netzladen.org/api/status.json",
   "Noklab": "https://cccgoe.de/spaceapi.php",
   "Nottinghack": "https://hms.nottinghack.org.uk/api/spaceapi ",
   "Nova Labs": "http://nova-labs.org/api/",


### PR DESCRIPTION
Netzladen is no longer existent, as stated here: https://netzladen.org/ "Der Netzladen ist geschlossen. Am 1. März 2018 wurde hier das letzte Plenum abgehalten. Die Räumlichkeiten werden renoviert und demnächst neu vermieten."