### PR TITLE
vsh is no longer, now operating as temporärhaus

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -198,7 +198,7 @@
   "shackspace - stuttgart hackerspace": "https://api.shackspace.de/v1/spaceapi",
   "spaceleft": "http://www.space-left.org/spaceapi13.json",
   "turmlabor": "http://www.turmlabor.de/spaces.api",
-  "verschwoerhaus": "https://verschwoerhaus.de/feed/spaceapi",
+  "temporärhaus": "https://spaceapi.temporaerhaus.de/spaceapi.json",
   "vspace.one": "https://vspace.one/spaceapi.json",
   "xHain": "https://x-hain.de/spaceapi-0.13.json",
   "z-Labor Zwickau": "http://api.service.z-labor.space/spaceapi.json"


### PR DESCRIPTION
Well, the City of Ulm legally forced us to change our name. So, we're currently operating as temporärhaus.  

More background in this blogpost (in german): https://temporaerhaus.de/stellungnahme-und-ausblick-zum-urteil-im-markenrechtsstreit/