### PR TITLE
Run CI on pull requests as well as on the master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 on:
   push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 name: CI
 


### PR DESCRIPTION
Previously all branches on the repo were checked with GitHub actions, but not pull requests from forks. Now all pull-requests to master and the master branch itself get checked.