### PR TITLE
Add Subraum

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -159,6 +159,7 @@
   "Stockholm Makerspace": "https://raw.githubusercontent.com/makerspace/spaceapi/main/spaceapi.json",
   "Spline": "https://iot.spline.de/api/status.json",
   "Stratum 0": "http://status.stratum0.org/status.json",
+  "Subraum (C3PB, Paderborn)": "https://c3pb.de/uptime.json",
   "Sudo Room": "http://api.sudoroom.org/status.json",
   "Swansea Hackspace": "http://swansea.hackspace.org.uk/spaceapi.php",
   "TDvenlo": "https://spaceapi.tdvenlo.nl/spaceapi.json",


### PR DESCRIPTION
The [validator](https://validator.spaceapi.io/ui/?url=https://c3pb.de/uptime.json) claims that the location doesn't match the address but it does match according to openstreetmap.org and latlong.net.