### PR TITLE
Add Pawprint Prototyping

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -145,6 +145,7 @@
   "Open-Lab Vorarlberg": "https://spaceapi.open-lab.at/spaceapi.php",
   "P'yŏngyang Hackerspace": "http://status.pyongyanghackerspace.org/jiwi.json",
   "Pangloss Labs #1": "https://spaceapi.panglosslabs.org/spaceapi.json",
+  "Pawprint Prototyping": "https://members.pawprintprototyping.org/api/spacedirectory/",
   "Perth Artifactory": "http://space.artifactory.org.au/spaceapi.json",
   "Pixelbar": "https://spaceapi.pixelbar.nl/",
   "Polytechnischer Werkraum Zittau": "https://www.werkraum.space/spaceapi/current/",


### PR DESCRIPTION
Adds [pawprintprototyping.org](https://pawprintprototyping.org/) - we are a small space in Santa Clara, California.

Furnished via the current version of the [MemberMatters SpaceDirectory integration](https://github.com/PawprintPrototyping/MemberMatters/blob/main/docs/SPACEDIRECTORY.md).

I've tried using the schema validator but see a 500 response from the validation backend when I try to submit, so not sure what's going on with that.  The output looks correct by my eye.