### PR TITLE
Remove defunct GeekLabs endpoint

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -62,7 +62,6 @@
   "Freies Labor": "https://freieslabor.org/api/info",
   "Fuz": "https://spaceapi.fuz.re/",
   "Garoa Hacker Clube": "https://garoahc.appspot.com/status",
-  "GeekLabs": "http://spaceapi.geeklabs.dk/?format=json",
   "Gold Coast Techspace": "https://raw.githubusercontent.com/gctechspace/spaceapi-endpoint/master/spaceapi.json",
   "H.A.C.K.": "https://vsza.hu/hacksense/spaceapi_status.json",
   "HSBNE (Hackerspace Brisbane)": "https://portal.hsbne.org/api/spacedirectory/",


### PR DESCRIPTION
I am the former domain/API endpoint/space admin of geeklabs.dk.

The domain was suspended on 2022-11-01, sorry for leaving the endpoint hanging in here this long.