### PR TITLE
Removed Chaosconsulting

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -28,7 +28,6 @@
   "CCCFr": "http://cccfr.de/status/spaceapi.py",
   "Chaos Computer Club Wien (C3W)": "https://api.space.c3w.at/status.json",
   "ChaosStuff": "https://spaceapi.c3l.lu/status.json",
-  "Chaosconsulting": "http://chaos-consulting.de/api/space.api",
   "Chaosdorf": "https://chaosdorf.de/space_api.json",
   "Chaospott": "https://status.chaospott.de/status.json",
   "Chaostreff Backnang": "https://spaceapi.ctbk.de",


### PR DESCRIPTION
Just removed Chaosconsulting as it was closed down some time ago. :-(

See also their still running webpage: https://chaos-consulting.de/

"Nach 7 Jahren wurde im November 2022 durch die Mitgliederversammlung die Auflösung des Vereins beschlossen." which roughtly translates into "After 7 years our member voted for the closure of our club in November 2022."