### PR TITLE
Renamed Awesome Space to AwesomeSpace

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -8,7 +8,7 @@
   "Apollo-NG": "https://apollo.open-resource.org/status.php",
   "Arch Reactor": "https://archreactor.org/status.php",
   "Attraktor Makerspace": "http://blog.attraktor.org/spaceapi/spaceapi.json",
-  "Awesome Space": "https://state.awesomespace.nl",
+  "AwesomeSpace": "https://state.awesomespace.nl",
   "B4CKSP4CE": "https://spaceapi.0x08.in/",
   "Bastli": "http://bastli.ch/hackspace_api.php",
   "Binary Kitchen": "https://www.binary-kitchen.de/spaceapi.php",


### PR DESCRIPTION
The correct spelling of AwesomeSpace is without a space, sorry