### PR TITLE
Add hacKNology e.V. to directory

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -86,6 +86,7 @@
   "Hacksaar": "http://spaceapi.hacksaar.de/status.json",
   "Hackspace Siegen": "https://status.hasi.it/",
   "Hakierspejs Łódź": "https://spaceapi.hs-ldz.pl/",
+  "hacKNology e.V.": "https://www.hacknology.de/spaceapi/status.json",
   "haxko": "https://api.haxko.space/",
   "HeatSync Labs": "http://members.heatsynclabs.org/space_api.json",
   "HTUGraz-ELab": "https://doorothy.htu.tugraz.at/doorothy/elab/status.spaceapi",


### PR DESCRIPTION
This adds "hacKNology e.V." to the directory. It is a hackerspace in Konstanz, Germany.