### PR TITLE
mainframe: use https

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -111,7 +111,7 @@
   "London Hackspace": "https://london.hackspace.org.uk/spaceapi",
   "LuXeria": "https://luxeria.ch/spaceapi.json",
   "Maakplek": "https://maakplek.nl/api/",
-  "Mainframe": "http://status.mainframe.io/api/spaceInfo",
+  "Mainframe": "https://status.mainframe.io/api/spaceInfo",
   "MakeMonmouth": "https://members.makemonmouth.co.uk/api/spacedirectory/",
   "MakeRiga": "https://api.makeriga.org/spaceapi.json",
   "MakeSpace Madrid": "https://makespacemadrid.org/spaceapi/status.json",


### PR DESCRIPTION
While the mainframe status SpaceApi is accessible via unencrypted http connections, we recommend using https when possible.