### PR TITLE
Hackspace Siegen: Update domain

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -86,7 +86,7 @@
   "Hacklab": "https://hacklab.kiev.ua/files/spaceapi.json",
   "Hacklabor": "https://hacklabor.de/api/space/v1/",
   "Hacksaar": "http://spaceapi.hacksaar.de/status.json",
-  "Hackspace Siegen": "https://status.hasi.it/",
+  "Hackspace Siegen": "https://status.ha.si/",
   "Hakierspejs Łódź": "https://spaceapi.hs-ldz.pl/",
   "hacKNology e.V.": "https://www.hacknology.de/spaceapi/status.json",
   "haxko": "https://api.haxko.space/",


### PR DESCRIPTION
We switched to our newer domain ha.si. The old domain is redirected, but that may result in CORS errors, for example on https://mapall.space. This should fix this.