### PR TITLE
Correct directory entry for Milwaukee Makerspace

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -139,7 +139,7 @@
   "Metro Olografix": "https://sede.olografix.org/spaceapi.json",
   "MidsouthMakers": "http://midsouthmakers.org/spaceapi/",
   "Milton Keynes Makerspace": "https://raw.githubusercontent.com/MKMakerSpace/spaceapi-endpoint/main/spaceapi.json",
-  "Milwaukee Makerspace": "http://apps.2xlnetworks.net/milwaukeemakerspace/",
+  "Milwaukee Makerspace": "https://milwaukeemakerspace.org/spaceapi.json",
   "Minsk Hackerspace": "https://hackerspace.by/spaceapi",
   "Mittelab": "https://api.mittelab.org/spaceapi",
   "Motionlab": "https://spaceapi.motionlab.berlin/",


### PR DESCRIPTION
Correct SpaceAPI Entry for Milwaukee Makerspace

If you're adding a new endpoint make sure that
 * [x] The new entry is at the correct (alphabetically sorted) line.
 * [ ] The endpoint is valid according to <https://validator.spaceapi.io/ui>
