### PR TITLE
Update Netz39 API endpoint

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -142,7 +142,7 @@
   "NURDSpace": "https://space.nurdspace.nl/spaceapi/status.json",
   "Nerd2Nerd": "https://api.nerd2nerd.org/status.json",
   "Nerdberg": "https://status.nerdberg.de/api/space",
-  "Netz39": "http://spaceapi.n39.eu/json",
+  "Netz39": "https://spaceapi.n39.eu/json",
   "Noklab": "https://cccgoe.de/spaceapi.php",
   "Nottinghack": "https://hms.nottinghack.org.uk/api/spaceapi",
   "Nova Labs": "http://nova-labs.org/api/",


### PR DESCRIPTION
We switched over to https some time ago, and did not setup a redirect from http.  This technically fixes our endpoint, security enhancement is more or less drive by.
