### PR TITLE
Added Makerspace (0xBA5E) Crailsheim

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -121,6 +121,7 @@
   "MakeSpace Madrid": "https://spaceapi.makespacemadrid.org",
   "Makers Local 256": "https://256.makerslocal.org/status.json",
   "Makers im Zigerschlitz": "https://api.zigerschlitzmakers.ch/space-api.json",
+  "Makerspace (0xBA5E) Crailsheim": "https://spaceapi.juze-cr.de/",
   "MakerSpace Bonn": "https://status.makerspacebonn.de/api/spaceapi",
   "Makerspace Erfurt": "https://status.makerspace-erfurt.de/status.json",
   "Makerspace Gütersloh": "https://makerspace-gt.de/space-api/space-api.json",


### PR DESCRIPTION
Added Makerspace (0xBA5E) Crailsheim

If you're adding a new endpoint make sure that
 * [x] The new entry is at the correct (alphabetically sorted) line.
 * [x] The endpoint is valid according to <https://validator.spaceapi.io/ui>
