### PR TITLE
base48: add new url for state api.

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -204,7 +204,7 @@
   "Zeus WPI": "https://mattermore.zeus.gent/spaceapi.json",
   "[hsmr]": "https://hsmr.cc/spaceapi.json",
   "backspace": "https://status.bckspc.de/spacestatus.php",
-  "base48": "https://48.io/status/",
+  "base48": "https://base48.cz/api/base_status_spaceapi.json",
   "brmlab": "https://brmlab.cz/spaceapi/brmstatus.json",
   "bytewerk": "http://stats.bytewerk.org/status.json",
   "chaostreff.ch": "https://chaostreff.ch/spaceapi.json",


### PR DESCRIPTION
If you're adding a new endpoint make sure that
 * [x] The new entry is at the correct (alphabetically sorted) line.
 * [x] The endpoint is valid according to <https://validator.spaceapi.io/ui>
