### PR TITLE
New location for space state of RandomData

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -171,7 +171,7 @@
   "Port39": "https://port39.de/spaceapi.json",
   "Post Tenebras Lab": "https://www.posttenebraslab.ch/status/status.json",
   "Programvareverkstedet": "https://www.pvv.ntnu.no/spaceapi.php",
-  "RandomData": "https://randomdata.sandervankasteel.nl/index.json",
+  "RandomData": "https://spacestate.lavalamp.randomdata.nl/index.json",
   "RaumZeitLabor": "https://status.raumzeitlabor.de/api/spaceapi.json",
   "Reaktor 23": "https://spaceapi.reaktor23.org",
   "Recompile": "http://www.recompile.se/spaceapi",


### PR DESCRIPTION
We've relocated the space state to a specific url, owned by the space