### PR TITLE
Add sandb0x hackerspace

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -235,6 +235,7 @@
   "nordlab e. V.": "http://spaceapi.nordlab-ev.de",
   "q30.space": "https://spaceapi.q30.space",
   "realraum": "https://status.realraum.at/spaceapi.json",
+  "sandb0x": "https://spaceapi.sandb0x.space/spaceapi.json",
   "section77": "https://api.section77.de/",
   "see-base": "https://bodensee.space/spaceapi/see-base.json",
   "shackspace - stuttgart hackerspace": "https://api.shackspace.de/v1/spaceapi",


### PR DESCRIPTION
adds the sandb0x hackerspace in Tbilisi

endpoint passes the official SpaceAPI validator for v15, HTTPS, CORS, content type, and certificate validity