### PR TITLE
Add GEOLab spaceapi endpoint

### DIFF
--- a/directory.json
+++ b/directory.json
@@ -70,6 +70,7 @@
   "Forschung und Technik e.V.": "https://spaceapi.futev.de/spaceapi.json",
   "Freies Labor": "https://freieslabor.org/api/info",
   "Fuz": "https://spaceapi.fuz.re/",
+  "GEOLab": "https://geolab.space/api/spacestatus",
   "Garoa Hacker Clube": "https://status.garoa.net.br/status",
   "Gold Coast Techspace": "https://raw.githubusercontent.com/gctechspace/spaceapi-endpoint/master/spaceapi.json",
   "H.A.C.K.": "https://vsza.hu/hacksense/spaceapi_status.json",


### PR DESCRIPTION
If you're adding a new endpoint make sure that
 * [x] The new entry is at the correct (alphabetically sorted) line.
 * [x] The endpoint is valid according to <https://validator.spaceapi.io/ui>

https://geolab.space/api/spacestatus
added CORS header and updated to confirm to v14 and v15 schema.